### PR TITLE
Support BG-3: BillingReference

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -10,6 +10,7 @@ use Einvoicing\Traits\AttachmentsTrait;
 use Einvoicing\Traits\BuyerAccountingReferenceTrait;
 use Einvoicing\Traits\InvoiceValidationTrait;
 use Einvoicing\Traits\PeriodTrait;
+use Einvoicing\Traits\PrecedingInvoiceReferencesTrait;
 use InvalidArgumentException;
 use OutOfBoundsException;
 use function array_splice;
@@ -34,7 +35,6 @@ class Invoice {
     protected $buyerReference = null;
     protected $purchaseOrderReference = null;
     protected $salesOrderReference = null;
-    protected $billingReference = null;
     protected $paidAmount = 0;
     protected $roundingAmount = 0;
     protected $seller = null;
@@ -49,6 +49,7 @@ class Invoice {
     use BuyerAccountingReferenceTrait;
     use PeriodTrait;
     use InvoiceValidationTrait;
+    use PrecedingInvoiceReferencesTrait;
 
     /**
      * Invoice constructor
@@ -328,26 +329,6 @@ class Invoice {
      */
     public function setSalesOrderReference(?string $salesOrderReference): self {
         $this->salesOrderReference = $salesOrderReference;
-        return $this;
-    }
-
-
-    /**
-     * Get billing reference
-     * @return string|null Billing reference
-     */
-    public function getBillingReference(): ?string {
-        return $this->billingReference;
-    }
-
-
-    /**
-     * Set sales order reference
-     * @param  string|null $billingReference Billing reference
-     * @return self                          Invoice instance
-     */
-    public function setBillingReference(?string $billingReference): self {
-        $this->billingReference = $billingReference;
         return $this;
     }
 

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -34,6 +34,7 @@ class Invoice {
     protected $buyerReference = null;
     protected $purchaseOrderReference = null;
     protected $salesOrderReference = null;
+    protected $billingReference = null;
     protected $paidAmount = 0;
     protected $roundingAmount = 0;
     protected $seller = null;
@@ -327,6 +328,26 @@ class Invoice {
      */
     public function setSalesOrderReference(?string $salesOrderReference): self {
         $this->salesOrderReference = $salesOrderReference;
+        return $this;
+    }
+
+
+    /**
+     * Get billing reference
+     * @return string|null Billing reference
+     */
+    public function getBillingReference(): ?string {
+        return $this->billingReference;
+    }
+
+
+    /**
+     * Set sales order reference
+     * @param  string|null $billingReference Billing reference
+     * @return self                          Invoice instance
+     */
+    public function setBillingReference(?string $billingReference): self {
+        $this->billingReference = $billingReference;
         return $this;
     }
 

--- a/src/InvoiceReference.php
+++ b/src/InvoiceReference.php
@@ -1,0 +1,59 @@
+<?php
+namespace Einvoicing;
+
+use DateTime;
+
+class InvoiceReference {
+    protected $value;
+    protected $issueDate;
+
+    /**
+     * Class constructor
+     * @param string        $value     Value
+     * @param DateTime|null $issueDate Issue date
+     */
+    public function __construct(string $value, ?DateTime $issueDate=null) {
+        $this->setValue($value);
+        $this->setIssueDate($issueDate);
+    }
+
+
+    /**
+     * Get value
+     * @return string Value
+     */
+    public function getValue(): string {
+        return $this->value;
+    }
+
+
+    /**
+     * Set value
+     * @param  string $value Value
+     * @return self          Invoice reference instance
+     */
+    public function setValue(string $value): self {
+        $this->value = $value;
+        return $this;
+    }
+
+
+    /**
+     * Get issue date
+     * @return DateTime|null Issue date
+     */
+    public function getIssueDate(): ?DateTime {
+        return $this->issueDate;
+    }
+
+
+    /**
+     * Set issue date
+     * @param  DateTime|null $issueDate Issue date
+     * @return self                     Invoice reference instance
+     */
+    public function setIssueDate(?DateTime $issueDate): self {
+        $this->issueDate = $issueDate;
+        return $this;
+    }
+}

--- a/src/Readers/UblReader.php
+++ b/src/Readers/UblReader.php
@@ -142,6 +142,12 @@ class UblReader extends AbstractReader {
             $invoice->setSalesOrderReference($salesOrderReferenceNode->asText());
         }
 
+        // BG-3: Billing Reference
+        $billingReference = $xml->get("{{$cac}}BillingReference/{{$cac}}InvoiceDocumentReference/{{$cbc}}ID");
+        if ($billingReference !== null) {
+            $invoice->setBillingReference($billingReference->asText());
+        }
+
         // BG-24: Attachment nodes
         foreach ($xml->getAll("{{$cac}}AdditionalDocumentReference") as $node) {
             $invoice->addAttachment($this->parseAttachmentNode($node));

--- a/src/Traits/PrecedingInvoiceReferencesTrait.php
+++ b/src/Traits/PrecedingInvoiceReferencesTrait.php
@@ -1,0 +1,53 @@
+<?php
+namespace Einvoicing\Traits;
+
+use Einvoicing\InvoiceReference;
+use OutOfBoundsException;
+
+trait PrecedingInvoiceReferencesTrait {
+    protected $precedingInvoiceReferences = [];
+
+    /**
+     * Get preceding invoice references
+     * @return InvoiceReference[] Array of preceding invoice references
+     */
+    public function getPrecedingInvoiceReferences(): array {
+        return $this->precedingInvoiceReferences;
+    }
+
+
+    /**
+     * Add preceding invoice reference
+     * @param  InvoiceReference $reference Preceding invoice reference
+     * @return self                        This instance
+     */
+    public function addPrecedingInvoiceReference(InvoiceReference $reference): self {
+        $this->precedingInvoiceReferences[] = $reference;
+        return $this;
+    }
+
+
+    /**
+     * Remove preceding invoice reference
+     * @param  int  $index Preceding invoice reference index
+     * @return self        This instance
+     * @throws OutOfBoundsException if preceding invoice reference index is out of bounds
+     */
+    public function removePrecedingInvoiceReference(int $index): self {
+        if ($index < 0 || $index >= count($this->precedingInvoiceReferences)) {
+            throw new OutOfBoundsException('Could not find preceding invoice reference by index');
+        }
+        array_splice($this->precedingInvoiceReferences, $index, 1);
+        return $this;
+    }
+
+
+    /**
+     * Clear all preceding invoice references
+     * @return self This instance
+     */
+    public function clearPrecedingInvoiceReferences(): self {
+        $this->precedingInvoiceReferences = [];
+        return $this;
+    }
+}

--- a/src/Writers/UblWriter.php
+++ b/src/Writers/UblWriter.php
@@ -96,6 +96,15 @@ class UblWriter extends AbstractWriter {
         // Order reference node
         $this->addOrderReferenceNode($xml, $invoice);
 
+        // BG-3: Billing reference
+        if ($invoice->getBillingReference()) {
+            $xml
+                ->add('cac:BillingReference')
+                ->add('cac:InvoiceDocumentReference')
+                ->add('cbc:ID', $invoice->getBillingReference())
+            ;
+        }
+
         // BG-24: Attachments node
         foreach ($invoice->getAttachments() as $attachment) {
             $this->addAttachmentNode($xml, $attachment);

--- a/src/Writers/UblWriter.php
+++ b/src/Writers/UblWriter.php
@@ -96,13 +96,14 @@ class UblWriter extends AbstractWriter {
         // Order reference node
         $this->addOrderReferenceNode($xml, $invoice);
 
-        // BG-3: Billing reference
-        if ($invoice->getBillingReference()) {
-            $xml
-                ->add('cac:BillingReference')
-                ->add('cac:InvoiceDocumentReference')
-                ->add('cbc:ID', $invoice->getBillingReference())
-            ;
+        // BG-3: Preceding invoice reference
+        foreach ($invoice->getPrecedingInvoiceReferences() as $invoiceReference) {
+            $invoiceDocumentReferenceNode = $xml->add('cac:BillingReference')->add('cac:InvoiceDocumentReference');
+            $invoiceDocumentReferenceNode->add('cbc:ID', $invoiceReference->getValue());
+            $invoiceReferenceIssueDate = $invoiceReference->getIssueDate();
+            if ($invoiceReferenceIssueDate !== null) {
+                $invoiceDocumentReferenceNode->add('cbc:IssueDate', $invoiceReferenceIssueDate->format('Y-m-d'));
+            }
         }
 
         // BG-24: Attachments node

--- a/tests/Integration/peppol-base.xml
+++ b/tests/Integration/peppol-base.xml
@@ -15,6 +15,17 @@
     <cac:OrderReference>
         <cbc:ID>854777</cbc:ID>
     </cac:OrderReference>
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>INV-122</cbc:ID>
+            <cbc:IssueDate>2021-09-21</cbc:IssueDate>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>INV-123</cbc:ID>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>INV-123</cbc:ID>
         <cbc:DocumentTypeCode>130</cbc:DocumentTypeCode>

--- a/tests/Readers/UblReaderTest.php
+++ b/tests/Readers/UblReaderTest.php
@@ -27,7 +27,7 @@ final class UblReaderTest extends TestCase {
         $this->assertEquals(1656.25, $totals->payableAmount);
         $this->assertEquals('S', $totals->vatBreakdown[0]->category);
         $this->assertEquals(25, $totals->vatBreakdown[0]->rate);
-        $this->assertEquals('INV-123', $invoice->getBillingReference());
+        $this->assertEquals('INV-123', $invoice->getPrecedingInvoiceReferences()[0]->getValue());
         $this->assertEquals('This is a sample string', $invoice->getAttachments()[0]->getContents());
     }
 }

--- a/tests/Readers/UblReaderTest.php
+++ b/tests/Readers/UblReaderTest.php
@@ -27,6 +27,7 @@ final class UblReaderTest extends TestCase {
         $this->assertEquals(1656.25, $totals->payableAmount);
         $this->assertEquals('S', $totals->vatBreakdown[0]->category);
         $this->assertEquals(25, $totals->vatBreakdown[0]->rate);
+        $this->assertEquals('INV-123', $invoice->getBillingReference());
         $this->assertEquals('This is a sample string', $invoice->getAttachments()[0]->getContents());
     }
 }

--- a/tests/Readers/peppol-example.xml
+++ b/tests/Readers/peppol-example.xml
@@ -12,6 +12,11 @@
     <ns:DocumentCurrencyCode>EUR</ns:DocumentCurrencyCode>
     <ns:AccountingCost>4025:123:4343</ns:AccountingCost>
     <ns:BuyerReference>0150abc</ns:BuyerReference>
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <ns:ID>INV-123</ns:ID>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
     <cac:AdditionalDocumentReference>
         <ns:ID>ABC-123</ns:ID>
         <ns:DocumentDescription>Invoice ABC-123</ns:DocumentDescription>

--- a/tests/Writers/UblWriterTest.php
+++ b/tests/Writers/UblWriterTest.php
@@ -70,6 +70,7 @@ final class UblWriterTest extends TestCase {
             ->setIssueDate(new DateTime('-3 days'))
             ->setDueDate(new DateTime('+30 days'))
             ->setBuyerReference('REF-0172637')
+            ->setBillingReference('INV-123')
             ->setSeller($seller)
             ->setBuyer($buyer)
             ->addLine($complexLine)

--- a/tests/Writers/UblWriterTest.php
+++ b/tests/Writers/UblWriterTest.php
@@ -7,6 +7,7 @@ use Einvoicing\Attachment;
 use Einvoicing\Identifier;
 use Einvoicing\Invoice;
 use Einvoicing\InvoiceLine;
+use Einvoicing\InvoiceReference;
 use Einvoicing\Party;
 use Einvoicing\Presets\Peppol;
 use Einvoicing\Writers\UblWriter;
@@ -70,7 +71,7 @@ final class UblWriterTest extends TestCase {
             ->setIssueDate(new DateTime('-3 days'))
             ->setDueDate(new DateTime('+30 days'))
             ->setBuyerReference('REF-0172637')
-            ->setBillingReference('INV-123')
+            ->addPrecedingInvoiceReference(new InvoiceReference('INV-123'))
             ->setSeller($seller)
             ->setBuyer($buyer)
             ->addLine($complexLine)


### PR DESCRIPTION
When creating credit notes (or subsequent invoices), we need to be able to include the original billing document to which the invoice/credit note refers.

More information on https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-BillingReference/

For now, only the ID is supported as this should be more than sufficient. Let me know if you want to include the optional issuing date as well. This will cause it to need a dedicated object for it though.