### PR TITLE
Add support for OriginatorDocumentReference

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -35,6 +35,7 @@ class Invoice {
     protected $buyerReference = null;
     protected $purchaseOrderReference = null;
     protected $salesOrderReference = null;
+    protected $originatorDocumentReference = null;
     protected $paidAmount = 0;
     protected $roundingAmount = 0;
     protected $seller = null;
@@ -329,6 +330,28 @@ class Invoice {
      */
     public function setSalesOrderReference(?string $salesOrderReference): self {
         $this->salesOrderReference = $salesOrderReference;
+        return $this;
+    }
+
+
+    /**
+     * Get originator document reference
+     * @return string|null
+     */
+    public function getOriginatorDocumentReference(): ?string
+    {
+        return $this->originatorDocumentReference;
+    }
+
+
+    /**
+     * Set originator document reference
+     * @param string|null $originatorDocumentReference
+     * @return Invoice
+     * @see https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-OriginatorDocumentReference/
+     */
+    public function setOriginatorDocumentReference(?string $originatorDocumentReference): self {
+        $this->originatorDocumentReference = $originatorDocumentReference;
         return $this;
     }
 

--- a/src/Readers/UblReader.php
+++ b/src/Readers/UblReader.php
@@ -157,6 +157,12 @@ class UblReader extends AbstractReader {
             $invoice->addPrecedingInvoiceReference($invoiceReference);
         }
 
+        // Originator Document Reference
+        $originatorDocumentReference = $xml->get("{{$cac}}OriginatorDocumentReference/{{$cbc}}ID");
+        if ($originatorDocumentReference !== null) {
+            $invoice->setOriginatorDocumentReference($originatorDocumentReference->asText());
+        }
+
         // BG-24: Attachment nodes
         foreach ($xml->getAll("{{$cac}}AdditionalDocumentReference") as $node) {
             $invoice->addAttachment($this->parseAttachmentNode($node));

--- a/src/Writers/UblWriter.php
+++ b/src/Writers/UblWriter.php
@@ -106,6 +106,13 @@ class UblWriter extends AbstractWriter {
             }
         }
 
+        $originatorDocumentReference = $invoice->getOriginatorDocumentReference();
+        if ($originatorDocumentReference) {
+            $xml
+                ->add('cac:OriginatorDocumentReference')
+                ->add('cbc:ID', $originatorDocumentReference);
+        }
+
         // BG-24: Attachments node
         foreach ($invoice->getAttachments() as $attachment) {
             $this->addAttachmentNode($xml, $attachment);

--- a/tests/Readers/peppol-example.xml
+++ b/tests/Readers/peppol-example.xml
@@ -17,6 +17,9 @@
             <ns:ID>INV-123</ns:ID>
         </cac:InvoiceDocumentReference>
     </cac:BillingReference>
+    <cac:OriginatorDocumentReference>
+        <ns:ID>PPID-123</ns:ID>
+    </cac:OriginatorDocumentReference>
     <cac:AdditionalDocumentReference>
         <ns:ID>ABC-123</ns:ID>
         <ns:DocumentDescription>Invoice ABC-123</ns:DocumentDescription>

--- a/tests/Writers/UblWriterTest.php
+++ b/tests/Writers/UblWriterTest.php
@@ -72,6 +72,7 @@ final class UblWriterTest extends TestCase {
             ->setDueDate(new DateTime('+30 days'))
             ->setBuyerReference('REF-0172637')
             ->addPrecedingInvoiceReference(new InvoiceReference('INV-123'))
+            ->setOriginatorDocumentReference('PPID-123')
             ->setSeller($seller)
             ->setBuyer($buyer)
             ->addLine($complexLine)


### PR DESCRIPTION
When creating an invoice we need to have a reference to the "lot" that this invoice belongs to.

See reference at https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-OriginatorDocumentReference/