### PR TITLE
Add support for ContractDocumentReference (BT-12)

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -36,6 +36,7 @@ class Invoice {
     protected $purchaseOrderReference = null;
     protected $salesOrderReference = null;
     protected $tenderOrLotReference = null;
+    protected $contractReference = null;
     protected $paidAmount = 0;
     protected $roundingAmount = 0;
     protected $seller = null;
@@ -350,6 +351,26 @@ class Invoice {
      */
     public function setTenderOrLotReference(?string $tenderOrLotReference): self {
         $this->tenderOrLotReference = $tenderOrLotReference;
+        return $this;
+    }
+
+
+    /**
+     * Get contract reference
+     * @return string|null Contract reference
+     */
+    public function getContractReference(): ?string {
+        return $this->contractReference;
+    }
+
+
+    /**
+     * Set contract reference
+     * @param  string|null $contractReference Contract reference
+     * @return self                           Invoice instance
+     */
+    public function setContractReference(?string $contractReference): self {
+        $this->contractReference = $contractReference;
         return $this;
     }
 

--- a/src/Readers/UblReader.php
+++ b/src/Readers/UblReader.php
@@ -163,6 +163,12 @@ class UblReader extends AbstractReader {
             $invoice->setTenderOrLotReference($tenderOrLotReferenceNode->asText());
         }
 
+        // BT-12: Contract reference
+        $contractReferenceNode = $xml->get("{{$cac}}ContractDocumentReference/{{$cbc}}ID");
+        if ($contractReferenceNode !== null) {
+            $invoice->setContractReference($contractReferenceNode->asText());
+        }
+
         // BG-24: Attachment nodes
         foreach ($xml->getAll("{{$cac}}AdditionalDocumentReference") as $node) {
             $invoice->addAttachment($this->parseAttachmentNode($node));

--- a/src/Writers/UblWriter.php
+++ b/src/Writers/UblWriter.php
@@ -112,6 +112,12 @@ class UblWriter extends AbstractWriter {
             $xml->add('cac:OriginatorDocumentReference')->add('cbc:ID', $tenderOrLotReference);
         }
 
+        // BT-12: Contract reference
+        $contractReference = $invoice->getContractReference();
+        if ($contractReference !== null) {
+            $xml->add('cac:ContractDocumentReference')->add('cbc:ID', $contractReference);
+        }
+
         // BG-24: Attachments node
         foreach ($invoice->getAttachments() as $attachment) {
             $this->addAttachmentNode($xml, $attachment);

--- a/tests/Integration/peppol-base.xml
+++ b/tests/Integration/peppol-base.xml
@@ -29,6 +29,9 @@
     <cac:OriginatorDocumentReference>
         <cbc:ID>PPID-123</cbc:ID>
     </cac:OriginatorDocumentReference>
+    <cac:ContractDocumentReference>
+        <cbc:ID>123Contractref</cbc:ID>
+    </cac:ContractDocumentReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>INV-123</cbc:ID>
         <cbc:DocumentTypeCode>130</cbc:DocumentTypeCode>

--- a/tests/Writers/UblWriterTest.php
+++ b/tests/Writers/UblWriterTest.php
@@ -73,6 +73,7 @@ final class UblWriterTest extends TestCase {
             ->setBuyerReference('REF-0172637')
             ->addPrecedingInvoiceReference(new InvoiceReference('INV-123'))
             ->setTenderOrLotReference('PPID-123')
+            ->setContractReference('123Contractref')
             ->setSeller($seller)
             ->setBuyer($buyer)
             ->addLine($complexLine)


### PR DESCRIPTION
Support the ContractDocumentReference field to be able to include a reference to a contract in the invoice.