### PR TITLE
Allow specifying InvoiceLine ID (BT-126)

### DIFF
--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -22,6 +22,7 @@ class InvoiceLine {
     protected $unit = "C62"; // TODO: add constants
     protected $price = null;
     protected $baseQuantity = 1;
+    protected $lineId = null;
 
     use AllowanceOrChargeTrait;
     use AttributesTrait;
@@ -331,5 +332,23 @@ class InvoiceLine {
         $netAmount -= $this->getAllowancesAmount($decimals);
         $netAmount += $this->getChargesAmount($decimals);
         return $netAmount;
+    }
+
+    /**
+     * Get Invoice line identifier
+     * @return string|null
+     */
+    public function getLineId(): ?string {
+        return $this->lineId;
+    }
+
+    /**
+     * Set Invoice line identifier
+     * @param string $lineId         The ID for the Line
+     * @return self                Invoice line instance
+     */
+    public function setLineId(string $lineId): self {
+        $this->lineId = $lineId;
+        return $this;
     }
 }

--- a/src/Readers/UblReader.php
+++ b/src/Readers/UblReader.php
@@ -698,6 +698,12 @@ class UblReader extends AbstractReader {
         $cac = UblWriter::NS_CAC;
         $cbc = UblWriter::NS_CBC;
 
+        // BT-126: Line ID
+        $lineId = $xml->get("{{$cbc}}ID");
+        if ($lineId) {
+            $line->setLineId($lineId->asText());
+        }
+
         // BT-127: Invoice line note
         $noteNode = $xml->get("{{$cbc}}Note");
         if ($noteNode !== null) {

--- a/src/Writers/UblWriter.php
+++ b/src/Writers/UblWriter.php
@@ -754,7 +754,7 @@ class UblWriter extends AbstractWriter {
         $xml = $parent->add('cac:InvoiceLine');
 
         // BT-126: Line ID
-        $xml->add('cbc:ID', (string) $index);
+        $xml->add('cbc:ID', $line->getLineId() ?? (string) $index);
 
         // BT-127: Invoice line note
         $note = $line->getNote();

--- a/tests/Writers/UblWriterTest.php
+++ b/tests/Writers/UblWriterTest.php
@@ -79,6 +79,7 @@ final class UblWriterTest extends TestCase {
             ->addLine($complexLine)
             ->addLine((new InvoiceLine)->setName('Line #2')->setPrice(40, 2)->setVatRate(21)->setQuantity(4))
             ->addLine((new InvoiceLine)->setName('Line #3')->setPrice(0.56)->setVatRate(10)->setQuantity(2))
+            ->addLine((new InvoiceLine)->setLineId('5')->setName('Line #4')->setPrice(0.56)->setVatRate(10)->setQuantity(2))
             ->addAllowance((new AllowanceOrCharge)->setReason('5% discount')->setAmount(5)->markAsPercentage()->setVatRate(21))
             ->addAttachment((new Attachment)->setId(new Identifier('INV-123', 'ABT')))
             ->addAttachment($externalAttachment)


### PR DESCRIPTION
This commit allows for specifying the ID of a InvoiceLine. Fallback to the line index if no ID is specified.

We need this, or some similar solution, to use the same line ID as was defined on a OrderLine on the InvoiceLine. 