### PR TITLE
Move rounding to last writing step

### DIFF
--- a/src/AllowanceOrCharge.php
+++ b/src/AllowanceOrCharge.php
@@ -2,7 +2,6 @@
 namespace Einvoicing;
 
 use Einvoicing\Traits\VatTrait;
-use function round;
 
 class AllowanceOrCharge {
     protected $reasonCode = null;
@@ -104,15 +103,14 @@ class AllowanceOrCharge {
     /**
      * Get effective amount relative to base amount
      * @param  float $baseAmount Base amount
-     * @param  int   $decimals   Number of decimal places
      * @return float             Effective amount
      */
-    public function getEffectiveAmount(float $baseAmount, int $decimals): float {
+    public function getEffectiveAmount(float $baseAmount): float {
         $amount = $this->getAmount();
         if ($this->isPercentage()) {
             $amount = $baseAmount * ($amount / 100);
         }
-        $amount = round($amount, $decimals);
+
         return $amount;
     }
 }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -16,7 +16,6 @@ use OutOfBoundsException;
 use function array_splice;
 use function count;
 use function is_subclass_of;
-use function round;
 
 class Invoice {
     const DEFAULT_DECIMALS = 8;
@@ -377,11 +376,10 @@ class Invoice {
 
     /**
      * Get invoice prepaid amount
-     * NOTE: may be rounded according to the CIUS specification
      * @return float Invoice prepaid amount
      */
     public function getPaidAmount(): float {
-        return round($this->paidAmount, $this->getDecimals('invoice/paidAmount'));
+        return $this->paidAmount;
     }
 
 
@@ -398,11 +396,10 @@ class Invoice {
 
     /**
      * Get invoice rounding amount
-     * NOTE: may be rounded according to the CIUS specification
      * @return float Invoice rounding amount
      */
     public function getRoundingAmount(): float {
-        return round($this->roundingAmount, $this->getDecimals('invoice/roundingAmount'));
+        return $this->roundingAmount;
     }
 
 

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -561,9 +561,10 @@ class Invoice {
 
     /**
      * Get invoice total
-     * @return InvoiceTotals Invoice totals
+     * @param  boolean       $round Whether to round values or not
+     * @return InvoiceTotals        Invoice totals
      */
-    public function getTotals(): InvoiceTotals {
-        return InvoiceTotals::fromInvoice($this);
+    public function getTotals(bool $round=true): InvoiceTotals {
+        return InvoiceTotals::fromInvoice($this, $round);
     }
 }

--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -7,7 +7,6 @@ use Einvoicing\Traits\BuyerAccountingReferenceTrait;
 use Einvoicing\Traits\ClassificationIdentifiersTrait;
 use Einvoicing\Traits\PeriodTrait;
 use Einvoicing\Traits\VatTrait;
-use function round;
 
 class InvoiceLine {
     protected $id = null;
@@ -297,27 +296,25 @@ class InvoiceLine {
 
     /**
      * Get total net amount (without VAT) before allowances/charges
-     * @param  int        $decimals Number of decimal places
      * @return float|null           Net amount before allowances/charges
      */
-    public function getNetAmountBeforeAllowancesCharges(int $decimals=Invoice::DEFAULT_DECIMALS): ?float {
+    public function getNetAmountBeforeAllowancesCharges(): ?float {
         if ($this->price === null) {
             return null;
         }
-        return round(($this->price / $this->baseQuantity) * $this->quantity, $decimals);
+        return ($this->price / $this->baseQuantity) * $this->quantity;
     }
 
 
     /**
      * Get allowances total amount
-     * @param  int   $decimals Number of decimal places
      * @return float           Allowances total amount
      */
-    public function getAllowancesAmount(int $decimals=Invoice::DEFAULT_DECIMALS): float {
+    public function getAllowancesAmount(): float {
         $allowancesAmount = 0;
-        $baseAmount = $this->getNetAmountBeforeAllowancesCharges($decimals) ?? 0;
+        $baseAmount = $this->getNetAmountBeforeAllowancesCharges() ?? 0.0;
         foreach ($this->getAllowances() as $item) {
-            $allowancesAmount += $item->getEffectiveAmount($baseAmount, $decimals);
+            $allowancesAmount += $item->getEffectiveAmount($baseAmount);
         }
         return $allowancesAmount;
     }
@@ -325,14 +322,13 @@ class InvoiceLine {
 
     /**
      * Get charges total amount
-     * @param  int   $decimals Number of decimal places
      * @return float           Charges total amount
      */
-    public function getChargesAmount(int $decimals=Invoice::DEFAULT_DECIMALS): float {
+    public function getChargesAmount(): float {
         $chargesAmount = 0;
-        $baseAmount = $this->getNetAmountBeforeAllowancesCharges($decimals) ?? 0;
+        $baseAmount = $this->getNetAmountBeforeAllowancesCharges() ?? 0.0;
         foreach ($this->getCharges() as $item) {
-            $chargesAmount += $item->getEffectiveAmount($baseAmount, $decimals);
+            $chargesAmount += $item->getEffectiveAmount($baseAmount);
         }
         return $chargesAmount;
     }
@@ -341,16 +337,15 @@ class InvoiceLine {
     /**
      * Get total net amount (without VAT)
      * NOTE: inclusive of line level allowances and charges
-     * @param  int        $decimals Number of decimal places
      * @return float|null           Net amount
      */
-    public function getNetAmount(int $decimals=Invoice::DEFAULT_DECIMALS): ?float {
-        $netAmount = $this->getNetAmountBeforeAllowancesCharges($decimals);
+    public function getNetAmount(): ?float {
+        $netAmount = $this->getNetAmountBeforeAllowancesCharges();
         if ($netAmount === null) {
             return null;
         }
-        $netAmount -= $this->getAllowancesAmount($decimals);
-        $netAmount += $this->getChargesAmount($decimals);
+        $netAmount -= $this->getAllowancesAmount();
+        $netAmount += $this->getChargesAmount();
         return $netAmount;
     }
 }

--- a/src/Models/InvoiceTotals.php
+++ b/src/Models/InvoiceTotals.php
@@ -12,55 +12,55 @@ class InvoiceTotals {
      */
     public $currency;
 
-    /** 
+    /**
      * Sum of all invoice line net amounts
      * @var float
      */
     public $netAmount = 0;
 
-    /** 
+    /**
      * Sum of all allowances on document level
      * @var float
      */
     public $allowancesAmount = 0;
 
-    /** 
+    /**
      * Sum of all charges on document level
      * @var float
      */
     public $chargesAmount = 0;
 
-    /** 
+    /**
      * Total VAT amount for the invoice
      * @var float
      */
     public $vatAmount = 0;
 
-    /** 
+    /**
      * Invoice total amount without VAT
      * @var float
      */
     public $taxExclusiveAmount = 0;
 
-    /** 
+    /**
      * Invoice total amount with VAT
      * @var float
      */
     public $taxInclusiveAmount = 0;
     
-    /** 
+    /**
      * The sum of amounts which have been paid in advance
      * @var float
      */
     public $paidAmount = 0;
 
-    /** 
+    /**
      * The amount to be added to the invoice total to round the amount to be paid
      * @var float
      */
     public $roundingAmount = 0;
 
-    /** 
+    /**
      * Amount due for payment
      * @var float
      */

--- a/src/Models/InvoiceTotals.php
+++ b/src/Models/InvoiceTotals.php
@@ -4,6 +4,7 @@ namespace Einvoicing\Models;
 use Einvoicing\Invoice;
 use Einvoicing\Traits\VatTrait;
 use function array_values;
+use function round;
 
 class InvoiceTotals {
     /**
@@ -74,10 +75,11 @@ class InvoiceTotals {
 
     /**
      * Create instance from invoice
-     * @param  Invoice $inv Invoice instance
-     * @return self         Totals instance
+     * @param  Invoice $inv   Invoice instance
+     * @param  boolean $round Whether to round values or not
+     * @return self           Totals instance
      */
-    static public function fromInvoice(Invoice $inv): InvoiceTotals {
+    static public function fromInvoice(Invoice $inv, bool $round=true): InvoiceTotals {
         $totals = new self();
         $vatMap = [];
 
@@ -118,6 +120,23 @@ class InvoiceTotals {
 
         // Attach VAT breakdown
         $totals->vatBreakdown = array_values($vatMap);
+
+        // Round values
+        if ($round) {
+            $totals->netAmount = round($totals->netAmount, $inv->getDecimals('invoice/netAmount'));
+            $totals->allowancesAmount = round($totals->allowancesAmount, $inv->getDecimals('invoice/allowancesChargesAmount'));
+            $totals->chargesAmount = round($totals->chargesAmount, $inv->getDecimals('invoice/allowancesChargesAmount'));
+            $totals->vatAmount = round($totals->vatAmount, $inv->getDecimals('invoice/vatAmount'));
+            $totals->taxExclusiveAmount = round($totals->taxExclusiveAmount, $inv->getDecimals('invoice/taxExclusiveAmount'));
+            $totals->taxInclusiveAmount = round($totals->taxInclusiveAmount, $inv->getDecimals('invoice/taxInclusiveAmount'));
+            $totals->paidAmount = round($totals->paidAmount, $inv->getDecimals('invoice/paidAmount'));
+            $totals->roundingAmount = round($totals->roundingAmount, $inv->getDecimals('invoice/roundingAmount'));
+            $totals->payableAmount = round($totals->payableAmount, $inv->getDecimals('invoice/payableAmount'));
+            foreach ($totals->vatBreakdown as $item) {
+                $item->taxableAmount = round($item->taxableAmount, $inv->getDecimals('invoice/allowancesChargesAmount'));
+                $item->taxAmount = round($item->taxAmount, $inv->getDecimals('invoice/taxAmount'));
+            }
+        }
 
         return $totals;
     }

--- a/src/Writers/UblWriter.php
+++ b/src/Writers/UblWriter.php
@@ -26,7 +26,7 @@ class UblWriter extends AbstractWriter {
      * @inheritdoc
      */
     public function export(Invoice $invoice): string {
-        $totals = $invoice->getTotals();
+        $totals = $invoice->getTotals(false);
         $xml = UXML::newInstance('Invoice', null, [
             'xmlns' => self::NS_INVOICE,
             'xmlns:cac' => self::NS_CAC,
@@ -645,7 +645,7 @@ class UblWriter extends AbstractWriter {
      * @param AllowanceOrCharge  $item     Allowance or charge instance
      * @param boolean            $isCharge Is charge (TRUE) or allowance (FALSE)
      * @param Invoice            $invoice  Invoice instance
-     * @param InvoiceTotals|null $totals   Invoice totals or NULL in case at line level
+     * @param InvoiceTotals|null $totals   Unrounded invoice totals or NULL in case at line level
      * @param InvoiceLine|null   $line     Invoice line or NULL in case of at document level
      */
     private function addAllowanceOrCharge(
@@ -711,7 +711,7 @@ class UblWriter extends AbstractWriter {
      * Add tax total node
      * @param UXML          $parent  Parent element
      * @param Invoice       $invoice Invoice instance
-     * @param InvoiceTotals $totals  Invoice totals
+     * @param InvoiceTotals $totals  Unrounded invoice totals
      */
     private function addTaxTotalNode(UXML $parent, Invoice $invoice, InvoiceTotals $totals) {
         $xml = $parent->add('cac:TaxTotal');
@@ -755,7 +755,7 @@ class UblWriter extends AbstractWriter {
      * Add document totals node
      * @param UXML          $parent  Parent element
      * @param Invoice       $invoice Invoice instance
-     * @param InvoiceTotals $totals  Invoice totals
+     * @param InvoiceTotals $totals  Unrounded invoice totals
      */
     private function addDocumentTotalsNode(UXML $parent, Invoice $invoice, InvoiceTotals $totals) {
         $xml = $parent->add('cac:LegalMonetaryTotal');

--- a/src/Writers/UblWriter.php
+++ b/src/Writers/UblWriter.php
@@ -679,13 +679,13 @@ class UblWriter extends AbstractWriter {
         // Amount
         $baseAmount = $atDocumentLevel ?
             $invoice->getTotals()->netAmount :
-            $line->getNetAmount($invoice->getDecimals('line/netAmount')) ?? 0; // @phan-suppress-current-line PhanPossiblyNonClassMethodCall
-        $amount = $item->getEffectiveAmount($baseAmount, $invoice->getDecimals('line/allowanceChargeAmount'));
-        $this->addAmountNode($xml, 'cbc:Amount', $amount, $invoice->getCurrency());
+            $line->getNetAmount() ?? 0.0; // @phan-suppress-current-line PhanPossiblyNonClassMethodCall
+        $amount = $item->getEffectiveAmount($baseAmount);
+        $this->addAmountNode($xml, 'cbc:Amount', round($amount, 2), $invoice->getCurrency());
 
         // Base amount
         if ($item->isPercentage()) {
-            $this->addAmountNode($xml, 'cbc:BaseAmount', $baseAmount, $invoice->getCurrency());
+            $this->addAmountNode($xml, 'cbc:BaseAmount', round($baseAmount, 2), $invoice->getCurrency());
         }
 
         // Tax category
@@ -704,13 +704,13 @@ class UblWriter extends AbstractWriter {
         $xml = $parent->add('cac:TaxTotal');
 
         // Add tax amount
-        $this->addAmountNode($xml, 'cbc:TaxAmount', $totals->vatAmount, $totals->currency);
+        $this->addAmountNode($xml, 'cbc:TaxAmount', round($totals->vatAmount, 2), $totals->currency);
 
         // Add each tax details
         foreach ($totals->vatBreakdown as $item) {
             $vatBreakdownNode = $xml->add('cac:TaxSubtotal');
-            $this->addAmountNode($vatBreakdownNode, 'cbc:TaxableAmount', $item->taxableAmount, $totals->currency);
-            $this->addAmountNode($vatBreakdownNode, 'cbc:TaxAmount', $item->taxAmount, $totals->currency);
+            $this->addAmountNode($vatBreakdownNode, 'cbc:TaxableAmount', round($item->taxableAmount, 2), $totals->currency);
+            $this->addAmountNode($vatBreakdownNode, 'cbc:TaxAmount', round($item->taxAmount, 2), $totals->currency);
             $this->addVatNode($vatBreakdownNode, 'cac:TaxCategory', $item->category, $item->rate,
                 $item->exemptionReasonCode, $item->exemptionReason);
         }
@@ -747,7 +747,7 @@ class UblWriter extends AbstractWriter {
 
         // Create and append XML nodes
         foreach ($totalsMatrix as $field=>$amount) {
-            $this->addAmountNode($xml, $field, $amount, $totals->currency);
+            $this->addAmountNode($xml, $field, round($amount, 2), $totals->currency);
         }
     }
 
@@ -782,9 +782,9 @@ class UblWriter extends AbstractWriter {
         $xml->add('cbc:InvoicedQuantity', (string) $line->getQuantity(), ['unitCode' => $line->getUnit()]);
 
         // BT-131: Line net amount
-        $netAmount = $line->getNetAmount($invoice->getDecimals('line/netAmount'));
+        $netAmount = $line->getNetAmount();
         if ($netAmount !== null) {
-            $this->addAmountNode($xml, 'cbc:LineExtensionAmount', $netAmount, $invoice->getCurrency());
+            $this->addAmountNode($xml, 'cbc:LineExtensionAmount', round($netAmount,2), $invoice->getCurrency());
         }
 
         // BT-133: Buyer accounting reference
@@ -871,7 +871,7 @@ class UblWriter extends AbstractWriter {
         // Price amount
         $price = $line->getPrice();
         if ($price !== null) {
-            $this->addAmountNode($priceNode, 'cbc:PriceAmount', $price, $invoice->getCurrency());
+            $this->addAmountNode($priceNode, 'cbc:PriceAmount', round($price, 2), $invoice->getCurrency());
         }
 
         // Base quantity

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -63,20 +63,9 @@ final class InvoiceTest extends TestCase {
           ->addLine((new InvoiceLine)->setPrice(34.343434343));
 
         $totals = $this->invoice->getTotals();
-        $this->assertEquals(123.456789, $totals->paidAmount);
-        $this->assertEquals(987.654321, $totals->roundingAmount);
-        $this->assertEquals(
-            123.4568,
-            round($totals->paidAmount, $this->invoice->getDecimals('invoice/paidAmount'))
-        );
-        $this->assertEquals(
-            987.654,
-            round($totals->roundingAmount, $this->invoice->getDecimals('invoice/roundingAmount'))
-        );
-        $this->assertEquals(
-            46.46464646,
-            round($totals->netAmount, $this->invoice->getDecimals('invoice/netAmount'))
-        );
+        $this->assertEquals(123.4568,    $totals->paidAmount);
+        $this->assertEquals(987.654,     $totals->roundingAmount);
+        $this->assertEquals(46.46464646, $totals->netAmount);
     }
 
     public function testTotalAmountsAreCalculatedCorrectly(): void {
@@ -91,7 +80,7 @@ final class InvoiceTest extends TestCase {
             ->addAllowance($allowance)
             ->addCharge($charge);
 
-        $totals = $this->invoice->getTotals();
+        $totals = $this->invoice->getTotals(false);
         $this->assertEquals(300.5,    $totals->netAmount);
         $this->assertEquals(12.34,    $totals->allowancesAmount);
         $this->assertEquals(22.5375,  $totals->chargesAmount);

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -54,17 +54,29 @@ final class InvoiceTest extends TestCase {
 
     public function testDecimalMatrixIsUsed(): void {
         $this->invoice->setRoundingMatrix([
-            "invoice/paidAmount" => 4,
-            "line/netAmount" => 8,
-            "" => 3
+            'invoice/paidAmount' => 4,
+            'invoice/netAmount' => 8,
+            '' => 3
         ])->setPaidAmount(123.456789)
           ->setRoundingAmount(987.654321)
           ->addLine((new InvoiceLine)->setPrice(12.121212121))
           ->addLine((new InvoiceLine)->setPrice(34.343434343));
 
-        $this->assertEquals(123.4568,    $this->invoice->getPaidAmount());
-        $this->assertEquals(987.654,     $this->invoice->getRoundingAmount());
-        $this->assertEquals(46.464646464, $this->invoice->getTotals()->netAmount);
+        $totals = $this->invoice->getTotals();
+        $this->assertEquals(123.456789, $totals->paidAmount);
+        $this->assertEquals(987.654321, $totals->roundingAmount);
+        $this->assertEquals(
+            123.4568,
+            round($totals->paidAmount, $this->invoice->getDecimals('invoice/paidAmount'))
+        );
+        $this->assertEquals(
+            987.654,
+            round($totals->roundingAmount, $this->invoice->getDecimals('invoice/roundingAmount'))
+        );
+        $this->assertEquals(
+            46.46464646,
+            round($totals->netAmount, $this->invoice->getDecimals('invoice/netAmount'))
+        );
     }
 
     public function testTotalAmountsAreCalculatedCorrectly(): void {

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -64,7 +64,7 @@ final class InvoiceTest extends TestCase {
 
         $this->assertEquals(123.4568,    $this->invoice->getPaidAmount());
         $this->assertEquals(987.654,     $this->invoice->getRoundingAmount());
-        $this->assertEquals(46.46464646, $this->invoice->getTotals()->netAmount);
+        $this->assertEquals(46.464646464, $this->invoice->getTotals()->netAmount);
     }
 
     public function testTotalAmountsAreCalculatedCorrectly(): void {
@@ -80,16 +80,16 @@ final class InvoiceTest extends TestCase {
             ->addCharge($charge);
 
         $totals = $this->invoice->getTotals();
-        $this->assertEquals(300.5,  $totals->netAmount);
-        $this->assertEquals(12.34,  $totals->allowancesAmount);
-        $this->assertEquals(22.54,  $totals->chargesAmount);
-        $this->assertEquals(52.11,  $totals->vatAmount);
-        $this->assertEquals(310.7,  $totals->taxExclusiveAmount);
-        $this->assertEquals(362.81, $totals->taxInclusiveAmount);
-        $this->assertEquals(10.2,   $totals->paidAmount);
-        $this->assertEquals(0,      $totals->roundingAmount);
-        $this->assertEquals(352.61, $totals->payableAmount);
-        $this->assertEquals(10,     $totals->vatBreakdown[0]->taxAmount);
-        $this->assertEquals(42.11,  $totals->vatBreakdown[1]->taxAmount);
+        $this->assertEquals(300.5,    $totals->netAmount);
+        $this->assertEquals(12.34,    $totals->allowancesAmount);
+        $this->assertEquals(22.5375,  $totals->chargesAmount);
+        $this->assertEquals(52.105,   $totals->vatAmount);
+        $this->assertEquals(310.6975, $totals->taxExclusiveAmount);
+        $this->assertEquals(362.8025, $totals->taxInclusiveAmount);
+        $this->assertEquals(10.2,     $totals->paidAmount);
+        $this->assertEquals(0,        $totals->roundingAmount);
+        $this->assertEquals(352.6025, $totals->payableAmount);
+        $this->assertEquals(10,       $totals->vatBreakdown[0]->taxAmount);
+        $this->assertEquals(42.105,   $totals->vatBreakdown[1]->taxAmount);
     }
 }


### PR DESCRIPTION
## Case:
Imagine a document with the following line (quantity = 2, price excl. = € 15,7025, vat = 21%)

<table>
<tr>
	<td>
	<td>Price Excl.
	<td>Quantity
	<td>Total Excl.
	<td>Vatpercentage
	<td>Vat amount
	<td>Total incl.
<tr>
	<td>CALCULATED
	<td>€ 15,7025
	<td>2
	<td>€ 31,405
	<td>21%
	<td>€ 6,59505
	<td>€ 38,00005
<tr>
	<td>VISUAL
	<td>€ 15,70
	<td>2
	<td>€ 31,41
	<td>21%
	<td>€ 6,60
	<td>€ 38,00
</table>

## Problem
We've been having issues where the xml has differences with the actual pdf document being sent to the customer. Due to this, the amount paid by the customer is different from the amount being booked into the book keeping software. As it turns out, this is due to the fact that amounts are rounded too soon.

The XML turns out like this:
<table>
<tr>
	<td>
	<td>Price Excl.
	<td>Quantity
	<td>Total Excl.
	<td>Vatpercentage
	<td>Vat amount
	<td>Total incl.
<tr>
	<td>XML
	<td>€ 15,70
	<td>2
	<td>€ 31,41
	<td>21%
	<td>€ 6,60
	<td>€ 38,01
</table>

As you can see, the total is `€ 38,01` instead of `€ 38,00`. This means our customer needs to change it back to € 38,00 because that is what their customer has actually paid from the original invoice.

## Solution
Normally when bookkeeping you are not allowed to round your numbers until the very end. So basically only once you start to visualise the number. Therefore I have moved the `round` calls to the very end in the `UblWriter`. This will make sure all calculations are done with the best precision before being outputted in XML.