### PR TITLE
feat: allow setting invoice totals

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -264,6 +264,7 @@ class Invoice {
     protected $delivery = null;
     protected $payment = null;
     protected $lines = [];
+    protected $totals = null;
 
     use AllowanceOrChargeTrait;
     use AttachmentsTrait;
@@ -889,6 +890,21 @@ class Invoice {
      * @return InvoiceTotals Invoice totals
      */
     public function getTotals(): InvoiceTotals {
+        if (!empty($this->totals)) {
+            return $this->totals;
+        }
+
         return InvoiceTotals::fromInvoice($this);
+    }
+
+    /**
+     * Set invoice total
+     * @param  InvoiceTotals $totals Invoice totals
+     * @return self                   Invoice instance
+     */
+    public function setTotals(InvoiceTotals $totals): self
+    {
+        $this->totals = $totals;
+        return $this;
     }
 }


### PR DESCRIPTION
Hi,

I came across a situation where the totals calculated by the library do not match. An example of this for 19% tax rate would be:
| Value w/o Taxes | VAT Value |
|--------|--------|
| 0.6 | 0.11 |
| 69.01 | 13.11 | 


In my ERP I add these values to get the totals, so:
Subtotal = 69.61
VAT = 13.22
Total = 82.83

But the VAT in the library is calculated on the whole sum, which when rounding adds and extra 0.01, resulting in:
Subtotal = 69.61
VAT = 13.23
Total = 82.84

By allowing the use of `setTotals()` I can get the initial calculated totals of the library and make adjustments where necessary.