### PR TITLE
Invoice line rounding

### DIFF
--- a/src/Models/InvoiceTotals.php
+++ b/src/Models/InvoiceTotals.php
@@ -157,13 +157,11 @@ class InvoiceTotals {
         return $totals;
     }
 
-
     /**
      * Update VAT map
-     * @param array<string,VatBreakdown> &$vatMap          VAT map reference
-     * @param VatTrait                   $item             Item instance
-     * @param float|null                 $rate             VAT rate
-     * @param float                      $addTaxableAmount Taxable amount to add
+     * @param array<string,VatBreakdown> &$vatMap VAT map reference
+     * @param VatTrait $item Item instance
+     * @param float $addTaxableAmount Taxable amount to add
      */
     static private function updateVatMap(array &$vatMap, $item, float $addTaxableAmount) {
         $category = $item->getVatCategory();

--- a/src/Models/InvoiceTotals.php
+++ b/src/Models/InvoiceTotals.php
@@ -99,7 +99,7 @@ class InvoiceTotals {
 
         // Process all invoice lines
         foreach ($inv->getLines() as $line) {
-            $lineNetAmount = $inv->round($line->getNetAmount() ?? 0.0, 'line/netAmount');
+            $lineNetAmount = $line->getNetAmount() ?? 0.0;
             $totals->netAmount += $lineNetAmount;
             self::updateVatMap($vatMap, $line, $lineNetAmount);
         }

--- a/src/Models/InvoiceTotals.php
+++ b/src/Models/InvoiceTotals.php
@@ -159,9 +159,9 @@ class InvoiceTotals {
 
     /**
      * Update VAT map
-     * @param array<string,VatBreakdown> &$vatMap VAT map reference
-     * @param VatTrait $item Item instance
-     * @param float $addTaxableAmount Taxable amount to add
+     * @param array<string,VatBreakdown> $vatMap           VAT map reference
+     * @param VatTrait                   $item             Item instance
+     * @param float                      $addTaxableAmount Taxable amount to add
      */
     static private function updateVatMap(array &$vatMap, $item, float $addTaxableAmount) {
         $category = $item->getVatCategory();


### PR DESCRIPTION
When each invoice line is rounded before the total rounding happens the result will be wrong according to systems like Fortnox, Visma Admin and others.

The rounding should only happen on the total value.