### PR TITLE
add a new NormalizesStringsTraitand normalize all input

### DIFF
--- a/src/Delivery.php
+++ b/src/Delivery.php
@@ -2,6 +2,7 @@
 namespace Einvoicing;
 
 use DateTime;
+use Einvoicing\Traits\NormalizesStringsTrait;
 use Einvoicing\Traits\PostalAddressTrait;
 
 class Delivery {
@@ -9,6 +10,7 @@ class Delivery {
     protected $date = null;
     protected $locationIdentifier = null;
 
+    use NormalizesStringsTrait;
     use PostalAddressTrait;
 
     /**
@@ -26,7 +28,7 @@ class Delivery {
      * @return self              Delivery instance
      */
     public function setName(?string $name): self {
-        $this->name = $name;
+        $this->name = $this->normalizeString($name);
         return $this;
     }
 

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -9,6 +9,7 @@ use Einvoicing\Traits\AllowanceOrChargeTrait;
 use Einvoicing\Traits\AttachmentsTrait;
 use Einvoicing\Traits\BuyerAccountingReferenceTrait;
 use Einvoicing\Traits\InvoiceValidationTrait;
+use Einvoicing\Traits\NormalizesStringsTrait;
 use Einvoicing\Traits\PeriodTrait;
 use Einvoicing\Traits\PrecedingInvoiceReferencesTrait;
 use InvalidArgumentException;
@@ -275,6 +276,7 @@ class Invoice {
     use AllowanceOrChargeTrait;
     use AttachmentsTrait;
     use BuyerAccountingReferenceTrait;
+    use NormalizesStringsTrait;
     use PeriodTrait;
     use InvoiceValidationTrait;
     use PrecedingInvoiceReferencesTrait;
@@ -371,7 +373,7 @@ class Invoice {
      * @return self                         Invoice instance
      */
     public function setBusinessProcess(?string $businessProcess): self {
-        $this->businessProcess = $businessProcess;
+        $this->businessProcess = $this->normalizeString($businessProcess);
         return $this;
     }
 
@@ -451,7 +453,7 @@ class Invoice {
      * @return self                      Invoice instance
      */
     public function setVatCurrency(?string $currencyCode): self {
-        $this->vatCurrency = $currencyCode;
+        $this->vatCurrency = $this->normalizeString($currencyCode);
         return $this;
     }
 
@@ -602,7 +604,7 @@ class Invoice {
      * @return self                        Invoice instance
      */
     public function setBuyerReference(?string $buyerReference): self {
-        $this->buyerReference = $buyerReference;
+        $this->buyerReference = $this->normalizeString($buyerReference);
         return $this;
     }
 
@@ -622,7 +624,7 @@ class Invoice {
      * @return self                                Invoice instance
      */
     public function setPurchaseOrderReference(?string $purchaseOrderReference): self {
-        $this->purchaseOrderReference = $purchaseOrderReference;
+        $this->purchaseOrderReference = $this->normalizeString($purchaseOrderReference);
         return $this;
     }
 
@@ -642,7 +644,7 @@ class Invoice {
      * @return self                             Invoice instance
      */
     public function setSalesOrderReference(?string $salesOrderReference): self {
-        $this->salesOrderReference = $salesOrderReference;
+        $this->salesOrderReference = $this->normalizeString($salesOrderReference);
         return $this;
     }
 
@@ -662,7 +664,7 @@ class Invoice {
      * @return self                              Invoice instance
      */
     public function setTenderOrLotReference(?string $tenderOrLotReference): self {
-        $this->tenderOrLotReference = $tenderOrLotReference;
+        $this->tenderOrLotReference = $this->normalizeString($tenderOrLotReference);
         return $this;
     }
 
@@ -682,7 +684,7 @@ class Invoice {
      * @return self                           Invoice instance
      */
     public function setContractReference(?string $contractReference): self {
-        $this->contractReference = $contractReference;
+        $this->contractReference = $this->normalizeString($contractReference);
         return $this;
     }
 
@@ -702,7 +704,7 @@ class Invoice {
      * @return self                           Invoice instance
      */
     public function setProjectReference(?string $projectReference): self {
-        $this->projectReference = $projectReference;
+        $this->projectReference = $this->normalizeString($projectReference);
         return $this;
     }
 
@@ -936,7 +938,7 @@ class Invoice {
      * @return self                      Invoice instance
      */
     public function setPaymentTerms(?string $paymentTerms): self {
-        $this->paymentTerms = $paymentTerms;
+        $this->paymentTerms = $this->normalizeString($paymentTerms);
         return $this;
     }
 

--- a/src/InvoiceLine.php
+++ b/src/InvoiceLine.php
@@ -5,6 +5,7 @@ use Einvoicing\Traits\AllowanceOrChargeTrait;
 use Einvoicing\Traits\AttributesTrait;
 use Einvoicing\Traits\BuyerAccountingReferenceTrait;
 use Einvoicing\Traits\ClassificationIdentifiersTrait;
+use Einvoicing\Traits\NormalizesStringsTrait;
 use Einvoicing\Traits\PeriodTrait;
 use Einvoicing\Traits\VatTrait;
 
@@ -27,6 +28,7 @@ class InvoiceLine {
     use AttributesTrait;
     use BuyerAccountingReferenceTrait;
     use ClassificationIdentifiersTrait;
+    use NormalizesStringsTrait;
     use PeriodTrait;
     use VatTrait;
 
@@ -65,7 +67,7 @@ class InvoiceLine {
      * @return self                   Invoice line instance
      */
     public function setOrderLineReference(?string $reference): self {
-        $this->orderLineReference = $reference;
+        $this->orderLineReference = $this->normalizeString($reference);
         return $this;
     }
 
@@ -105,7 +107,7 @@ class InvoiceLine {
      * @return self                     Invoice line instance
      */
     public function setDescription(?string $description): self {
-        $this->description = $description;
+        $this->description = $this->normalizeString($description);
         return $this;
     }
 
@@ -125,7 +127,7 @@ class InvoiceLine {
      * @return self                       Invoice line instance
      */
     public function setOriginCountry(?string $originCountry): self {
-        $this->originCountry = $originCountry;
+        $this->originCountry = $this->normalizeString($originCountry);
         return $this;
     }
 
@@ -145,7 +147,7 @@ class InvoiceLine {
      * @return self              Invoice line instance
      */
     public function setNote(?string $note): self {
-        $this->note = $note;
+        $this->note = $this->normalizeString($note);
         return $this;
     }
 
@@ -185,7 +187,7 @@ class InvoiceLine {
      * @return self                    Invoice line instance
      */
     public function setBuyerIdentifier(?string $identifier): self {
-        $this->buyerIdentifier = $identifier;
+        $this->buyerIdentifier = $this->normalizeString($identifier);
         return $this;
     }
 
@@ -205,7 +207,7 @@ class InvoiceLine {
      * @return self                    Invoice line instance
      */
     public function setSellerIdentifier(?string $identifier): self {
-        $this->sellerIdentifier = $identifier;
+        $this->sellerIdentifier = $this->normalizeString($identifier);
         return $this;
     }
 

--- a/src/Party.php
+++ b/src/Party.php
@@ -2,6 +2,7 @@
 namespace Einvoicing;
 
 use Einvoicing\Traits\IdentifiersTrait;
+use Einvoicing\Traits\NormalizesStringsTrait;
 use Einvoicing\Traits\PostalAddressTrait;
 
 class Party {
@@ -17,6 +18,7 @@ class Party {
     protected $contactEmail = null;
 
     use IdentifiersTrait;
+    use NormalizesStringsTrait;
     use PostalAddressTrait;
 
     /**
@@ -54,7 +56,7 @@ class Party {
      * @return self              Party instance
      */
     public function setName(?string $name): self {
-        $this->name = $name;
+        $this->name = $this->normalizeString($name);
         return $this;
     }
 
@@ -74,7 +76,7 @@ class Party {
      * @return self                     Party instance
      */
     public function setTradingName(?string $tradingName): self {
-        $this->tradingName = $tradingName;
+        $this->tradingName = $this->normalizeString($tradingName);
         return $this;
     }
 
@@ -114,7 +116,7 @@ class Party {
      * @return self                   Party instance
      */
     public function setVatNumber(?string $vatNumber): self {
-        $this->vatNumber = $vatNumber;
+        $this->vatNumber = $this->normalizeString($vatNumber);
         return $this;
     }
 
@@ -154,7 +156,7 @@ class Party {
      * @return self                         Party instance
      */
     public function setLegalInformation(?string $legalInformation): self {
-        $this->legalInformation = $legalInformation;
+        $this->legalInformation = $this->normalizeString($legalInformation);
         return $this;
     }
 
@@ -174,7 +176,7 @@ class Party {
      * @return self                     This instance
      */
     public function setContactName(?string $contactName): self {
-        $this->contactName = $contactName;
+        $this->contactName = $this->normalizeString($contactName);
         return $this;
     }
 
@@ -194,7 +196,7 @@ class Party {
      * @return self                      This instance
      */
     public function setContactPhone(?string $contactPhone): self {
-        $this->contactPhone = $contactPhone;
+        $this->contactPhone = $this->normalizeString($contactPhone);
         return $this;
     }
 
@@ -214,7 +216,7 @@ class Party {
      * @return self                      This instance
      */
     public function setContactEmail(?string $contactEmail): self {
-        $this->contactEmail = $contactEmail;
+        $this->contactEmail = $this->normalizeString($contactEmail);
         return $this;
     }
 

--- a/src/Payments/Card.php
+++ b/src/Payments/Card.php
@@ -1,7 +1,10 @@
 <?php
 namespace Einvoicing\Payments;
 
+use Einvoicing\Traits\NormalizesStringsTrait;
+
 class Card {
+    use NormalizesStringsTrait;
     protected $pan = null;
     protected $network = null;
     protected $holder = null;
@@ -41,7 +44,7 @@ class Card {
      * @return self                 Card instance
      */
     public function setNetwork(?string $network): self {
-        $this->network = $network;
+        $this->network = $this->normalizeString($network);
         return $this;
     }
 
@@ -61,7 +64,7 @@ class Card {
      * @return self                Card instance
      */
     public function setHolder(?string $holder): self {
-        $this->holder = $holder;
+        $this->holder = $this->normalizeString($holder);
         return $this;
     }
 }

--- a/src/Payments/Mandate.php
+++ b/src/Payments/Mandate.php
@@ -1,7 +1,10 @@
 <?php
 namespace Einvoicing\Payments;
 
+use Einvoicing\Traits\NormalizesStringsTrait;
+
 class Mandate {
+    use NormalizesStringsTrait;
     protected $reference = null;
     protected $account = null;
 
@@ -20,7 +23,7 @@ class Mandate {
      * @return self                   Mandate instance
      */
     public function setReference(?string $reference): self {
-        $this->reference = $reference;
+        $this->reference = $this->normalizeString($reference);
         return $this;
     }
 
@@ -40,7 +43,7 @@ class Mandate {
      * @return self                 Mandate instance
      */
     public function setAccount(?string $account): self {
-        $this->account = $account;
+        $this->account = $this->normalizeString($account);
         return $this;
     }
 }

--- a/src/Payments/Payment.php
+++ b/src/Payments/Payment.php
@@ -1,6 +1,7 @@
 <?php
 namespace Einvoicing\Payments;
 
+use Einvoicing\Traits\NormalizesStringsTrait;
 use OutOfBoundsException;
 use const E_USER_DEPRECATED;
 use function array_splice;
@@ -8,6 +9,7 @@ use function count;
 use function trigger_error;
 
 class Payment {
+    use NormalizesStringsTrait;
     protected $id = null;
     protected $meansCode = null;
     protected $meansText = null;
@@ -31,7 +33,7 @@ class Payment {
      * @return self            Payment instance
      */
     public function setId(?string $id): self {
-        $this->id = $id;
+        $this->id = $this->normalizeString($id);
         return $this;
     }
 
@@ -71,7 +73,7 @@ class Payment {
      * @return self                   Payment instance
      */
     public function setMeansText(?string $meansText): self {
-        $this->meansText = $meansText;
+        $this->meansText = $this->normalizeString($meansText);
         return $this;
     }
 
@@ -103,7 +105,7 @@ class Payment {
         if (!$internal) {
             trigger_error('Payment::setTerms() is deprecated and will be removed in the next version of josemmo/einvoicing', E_USER_DEPRECATED);
         }
-        $this->terms = $terms;
+        $this->terms = $this->normalizeString($terms);
         return $this;
     }
 

--- a/src/Payments/Transfer.php
+++ b/src/Payments/Transfer.php
@@ -1,7 +1,10 @@
 <?php
 namespace Einvoicing\Payments;
 
+use Einvoicing\Traits\NormalizesStringsTrait;
+
 class Transfer {
+    use NormalizesStringsTrait;
     protected $accountId = null;
     protected $accountName = null;
     protected $provider = null;
@@ -41,7 +44,7 @@ class Transfer {
      * @return self                     Transfer instance
      */
     public function setAccountName(?string $accountName): self {
-        $this->accountName = $accountName;
+        $this->accountName = $this->normalizeString($accountName);
         return $this;
     }
 
@@ -61,7 +64,7 @@ class Transfer {
      * @return self                  Transfer instance
      */
     public function setProvider(?string $provider): self {
-        $this->provider = $provider;
+        $this->provider = $this->normalizeString($provider);
         return $this;
     }
 }

--- a/src/Traits/NormalizesStringsTrait.php
+++ b/src/Traits/NormalizesStringsTrait.php
@@ -1,0 +1,19 @@
+<?php
+namespace Einvoicing\Traits;
+
+trait NormalizesStringsTrait {
+    /**
+     * Normalize a string value
+     * Trims whitespace and converts empty strings to null.
+     * This ensures Peppol validation compliance as normalize-space() is used in Schematron rules.
+     * @param  string|null $value Input value
+     * @return string|null        Normalized value or null if empty
+     */
+    private function normalizeString(?string $value): ?string {
+        if ($value === null) {
+            return null;
+        }
+        $trimmed = trim($value);
+        return $trimmed === '' ? null : $trimmed;
+    }
+}

--- a/src/Traits/PostalAddressTrait.php
+++ b/src/Traits/PostalAddressTrait.php
@@ -50,7 +50,7 @@ trait PostalAddressTrait {
      * @return self              This instance
      */
     public function setCity(?string $city): self {
-        $this->city = $city;
+        $this->city = $this->normalizeString($city);
         return $this;
     }
 
@@ -70,7 +70,7 @@ trait PostalAddressTrait {
      * @return self                    This instance
      */
     public function setPostalCode(?string $postalCode): self {
-        $this->postalCode = $postalCode;
+        $this->postalCode = $this->normalizeString($postalCode);
         return $this;
     }
 
@@ -90,7 +90,7 @@ trait PostalAddressTrait {
      * @return self                     This instance
      */
     public function setSubdivision(?string $subdivision): self {
-        $this->subdivision = $subdivision;
+        $this->subdivision = $this->normalizeString($subdivision);
         return $this;
     }
 
@@ -110,7 +110,7 @@ trait PostalAddressTrait {
      * @return self                     This instance
      */
     public function setCountry(?string $countryCode): self {
-        $this->country = $countryCode;
+        $this->country = $this->normalizeString($countryCode);
         return $this;
     }
 }

--- a/src/Traits/PostalAddressTrait.php
+++ b/src/Traits/PostalAddressTrait.php
@@ -5,6 +5,8 @@ use InvalidArgumentException;
 use function count;
 
 trait PostalAddressTrait {
+    use NormalizesStringsTrait;
+
     protected $address = [];
     protected $city = null;
     protected $postalCode = null;

--- a/src/Writers/UblWriter.php
+++ b/src/Writers/UblWriter.php
@@ -483,7 +483,7 @@ class UblWriter extends AbstractWriter {
         // Contact point
         if ($party->hasContactInformation()) {
             $contactNode = $xml->add('cac:Contact');
-            
+
             $contactName = $party->getContactName();
             if ($contactName !== null) {
                 $contactNode->add('cbc:Name', $contactName);


### PR DESCRIPTION
Hello @josemmo 
as i have lot of ERP databases with " " (spaces) as email for customers contacts (or other fields like city name) i made that contribution to your incredible lib. Then empty strings or strings with only spaces are considered as null during input / set.

then ublwriter does not made empty blocs according to peppol rules with normalize-space

https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-peppol/PEPPOL-EN16931-R008/

`not(normalize-space())`

thanks to https://developer.mozilla.org/docs/Web/XML/XPath/Reference/Functions/normalize-space normalize space is like php `trim`